### PR TITLE
Update dgambin.R

### DIFF
--- a/R/dgambin.R
+++ b/R/dgambin.R
@@ -1,26 +1,18 @@
 dgambin <-
 function(alpha, maxoctave)
 {
-  # a function to give the probability distribution of the GamBin in 
-  Pk <- function(alpha, k, octmax) # k is in 0:(nOct-1)
-  {
-    # calculates the 'fitness' distribution of species for a given alpha
-    Gj <- function(alpha, j) # j is an integer in 1:100
-    {
-      qG99 = qgamma(0.99, alpha, 1) / 100
-      b1 = (j - 1) * qG99
-      b2 = j * qG99
-      
-      return((pgamma(b2, alpha, 1) - pgamma(b1, alpha, 1)) / 0.99)
-    }
-    
-    s <- 0
-    for (j in 1:100)
-      s[j] <- choose(octmax, k) * (j / 100) ^ k * (1 - j/100) ^ (octmax - k) * Gj(alpha, j)
-    return(sum(s))
-  }
+  # calculates the 'fitness' distribution of species for a given alpha
+  qG99 = qgamma(0.99, alpha, 1) / 100
+  b1 = 0:99 * qG99
+  b2 = 1:100 * qG99
+  Gj <- (pgamma(b2, alpha, 1) - pgamma(b1, alpha, 1)) / 0.99
   
-  ret <- sapply(0:maxoctave, Pk, alpha = alpha, octmax = maxoctave)
+  # a function to give the probability distribution of the GamBin in 
+  Pk <- function(k, octmax) # k is in 0:(nOct-1)
+    return(sum(choose(octmax, k) * (1:100/100)^k * (1 - 1:100/100)^(octmax - k) * Gj)) 
+  
+  # applies Pk to each octave:
+  ret <- sapply(0:maxoctave, Pk, octmax = maxoctave)
   names(ret) <- 0:maxoctave
   ret
 }


### PR DESCRIPTION
Gj can be calculated only once for all values 1:100, because pgamma allows a whole vector of quantiles as input. It is not necessary to be calculated for each j for each k for each octave. Taking the calculation of Gj out of the Pk function makes the Pk function to be more concise (the alpha parameter is not necessary any more within Pk). Note that when Gj is expressed as a vector, the whole calculation of s can be done over vectors instead of over single scalars. So "j" can be substituted by "1:100", and the for loop is therefore not necessary. The new version of this Pk function is >10 times faster than the old one, so the whole function dgambin improves its performance.
